### PR TITLE
sky130_sram_* modules pins sizes changed to be slightly > 0.24

### DIFF
--- a/sky130_sram_1kbyte_1rw1r_32x256_8/sky130_sram_1kbyte_1rw1r_32x256_8.lef
+++ b/sky130_sram_1kbyte_1rw1r_32x256_8/sky130_sram_1kbyte_1rw1r_32x256_8.lef
@@ -13,847 +13,847 @@ MACRO sky130_sram_1kbyte_1rw1r_32x256_8
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  104.72 0.0 105.1 0.38 ;
+         RECT  104.72 0.0 105.1 0.64 ;
       END
    END din0[0]
    PIN din0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  110.84 0.0 111.22 0.38 ;
+         RECT  110.84 0.0 111.22 0.64 ;
       END
    END din0[1]
    PIN din0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  116.28 0.0 116.66 0.38 ;
+         RECT  116.28 0.0 116.66 0.64 ;
       END
    END din0[2]
    PIN din0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  123.08 0.0 123.46 0.38 ;
+         RECT  123.08 0.0 123.46 0.64 ;
       END
    END din0[3]
    PIN din0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  128.52 0.0 128.9 0.38 ;
+         RECT  128.52 0.0 128.9 0.64 ;
       END
    END din0[4]
    PIN din0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  133.96 0.0 134.34 0.38 ;
+         RECT  133.96 0.0 134.34 0.64 ;
       END
    END din0[5]
    PIN din0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  139.4 0.0 139.78 0.38 ;
+         RECT  139.4 0.0 139.78 0.64 ;
       END
    END din0[6]
    PIN din0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  146.2 0.0 146.58 0.38 ;
+         RECT  146.2 0.0 146.58 0.64 ;
       END
    END din0[7]
    PIN din0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  151.64 0.0 152.02 0.38 ;
+         RECT  151.64 0.0 152.02 0.64 ;
       END
    END din0[8]
    PIN din0[9]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  157.08 0.0 157.46 0.38 ;
+         RECT  157.08 0.0 157.46 0.64 ;
       END
    END din0[9]
    PIN din0[10]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  163.2 0.0 163.58 0.38 ;
+         RECT  163.2 0.0 163.58 0.64 ;
       END
    END din0[10]
    PIN din0[11]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  168.64 0.0 169.02 0.38 ;
+         RECT  168.64 0.0 169.02 0.64 ;
       END
    END din0[11]
    PIN din0[12]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  175.44 0.0 175.82 0.38 ;
+         RECT  175.44 0.0 175.82 0.64 ;
       END
    END din0[12]
    PIN din0[13]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  180.88 0.0 181.26 0.38 ;
+         RECT  180.88 0.0 181.26 0.64 ;
       END
    END din0[13]
    PIN din0[14]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  186.32 0.0 186.7 0.38 ;
+         RECT  186.32 0.0 186.7 0.64 ;
       END
    END din0[14]
    PIN din0[15]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  192.44 0.0 192.82 0.38 ;
+         RECT  192.44 0.0 192.82 0.64 ;
       END
    END din0[15]
    PIN din0[16]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  199.24 0.0 199.62 0.38 ;
+         RECT  199.24 0.0 199.62 0.64 ;
       END
    END din0[16]
    PIN din0[17]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  204.68 0.0 205.06 0.38 ;
+         RECT  204.68 0.0 205.06 0.64 ;
       END
    END din0[17]
    PIN din0[18]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  210.12 0.0 210.5 0.38 ;
+         RECT  210.12 0.0 210.5 0.64 ;
       END
    END din0[18]
    PIN din0[19]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  215.56 0.0 215.94 0.38 ;
+         RECT  215.56 0.0 215.94 0.64 ;
       END
    END din0[19]
    PIN din0[20]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  222.36 0.0 222.74 0.38 ;
+         RECT  222.36 0.0 222.74 0.64 ;
       END
    END din0[20]
    PIN din0[21]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  227.8 0.0 228.18 0.38 ;
+         RECT  227.8 0.0 228.18 0.64 ;
       END
    END din0[21]
    PIN din0[22]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  233.24 0.0 233.62 0.38 ;
+         RECT  233.24 0.0 233.62 0.64 ;
       END
    END din0[22]
    PIN din0[23]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  239.36 0.0 239.74 0.38 ;
+         RECT  239.36 0.0 239.74 0.64 ;
       END
    END din0[23]
    PIN din0[24]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  244.8 0.0 245.18 0.38 ;
+         RECT  244.8 0.0 245.18 0.64 ;
       END
    END din0[24]
    PIN din0[25]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  251.6 0.0 251.98 0.38 ;
+         RECT  251.6 0.0 251.98 0.64 ;
       END
    END din0[25]
    PIN din0[26]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  257.04 0.0 257.42 0.38 ;
+         RECT  257.04 0.0 257.42 0.64 ;
       END
    END din0[26]
    PIN din0[27]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  262.48 0.0 262.86 0.38 ;
+         RECT  262.48 0.0 262.86 0.64 ;
       END
    END din0[27]
    PIN din0[28]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  267.92 0.0 268.3 0.38 ;
+         RECT  267.92 0.0 268.3 0.64 ;
       END
    END din0[28]
    PIN din0[29]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  274.04 0.0 274.42 0.38 ;
+         RECT  274.04 0.0 274.42 0.64 ;
       END
    END din0[29]
    PIN din0[30]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  280.84 0.0 281.22 0.38 ;
+         RECT  280.84 0.0 281.22 0.64 ;
       END
    END din0[30]
    PIN din0[31]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  286.28 0.0 286.66 0.38 ;
+         RECT  286.28 0.0 286.66 0.64 ;
       END
    END din0[31]
    PIN addr0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  75.48 0.0 75.86 0.38 ;
+         RECT  75.48 0.0 75.86 0.64 ;
       END
    END addr0[0]
    PIN addr0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 127.16 0.38 127.54 ;
+         RECT  0.0 127.16 0.64 127.54 ;
       END
    END addr0[1]
    PIN addr0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 135.32 0.38 135.7 ;
+         RECT  0.0 135.32 0.64 135.7 ;
       END
    END addr0[2]
    PIN addr0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 140.76 0.38 141.14 ;
+         RECT  0.0 140.76 0.64 141.14 ;
       END
    END addr0[3]
    PIN addr0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 148.92 0.38 149.3 ;
+         RECT  0.0 148.92 0.64 149.3 ;
       END
    END addr0[4]
    PIN addr0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 154.36 0.38 154.74 ;
+         RECT  0.0 154.36 0.64 154.74 ;
       END
    END addr0[5]
    PIN addr0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 163.2 0.38 163.58 ;
+         RECT  0.0 163.2 0.64 163.58 ;
       END
    END addr0[6]
    PIN addr0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 168.64 0.38 169.02 ;
+         RECT  0.0 168.64 0.64 169.02 ;
       END
    END addr0[7]
    PIN addr1[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  395.08 394.4 395.46 394.78 ;
+         RECT  395.08 394.14 395.46 394.78 ;
       END
    END addr1[0]
    PIN addr1[1]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  475.32 81.6 475.7 81.98 ;
+         RECT  475.06 81.6 475.7 81.98 ;
       END
    END addr1[1]
    PIN addr1[2]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  475.32 73.44 475.7 73.82 ;
+         RECT  475.06 73.44 475.7 73.82 ;
       END
    END addr1[2]
    PIN addr1[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  475.32 67.32 475.7 67.7 ;
+         RECT  475.06 67.32 475.7 67.7 ;
       END
    END addr1[3]
    PIN addr1[4]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  413.44 0.0 413.82 0.38 ;
+         RECT  413.44 0.0 413.82 0.64 ;
       END
    END addr1[4]
    PIN addr1[5]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  411.4 0.0 411.78 0.38 ;
+         RECT  411.4 0.0 411.78 0.64 ;
       END
    END addr1[5]
    PIN addr1[6]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  412.08 0.0 412.46 0.38 ;
+         RECT  412.08 0.0 412.46 0.64 ;
       END
    END addr1[6]
    PIN addr1[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  412.76 0.0 413.14 0.38 ;
+         RECT  412.76 0.0 413.14 0.64 ;
       END
    END addr1[7]
    PIN csb0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 25.16 0.38 25.54 ;
+         RECT  0.0 25.16 0.64 25.54 ;
       END
    END csb0
    PIN csb1
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  475.32 381.48 475.7 381.86 ;
+         RECT  475.06 381.48 475.7 381.86 ;
       END
    END csb1
    PIN web0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 34.0 0.38 34.38 ;
+         RECT  0.0 34.0 0.64 34.38 ;
       END
    END web0
    PIN clk0
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  27.2 0.0 27.58 0.38 ;
+         RECT  27.2 0.0 27.58 0.64 ;
       END
    END clk0
    PIN clk1
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  448.12 394.4 448.5 394.78 ;
+         RECT  448.12 394.14 448.5 394.78 ;
       END
    END clk1
    PIN wmask0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  81.6 0.0 81.98 0.38 ;
+         RECT  81.6 0.0 81.98 0.64 ;
       END
    END wmask0[0]
    PIN wmask0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  87.04 0.0 87.42 0.38 ;
+         RECT  87.04 0.0 87.42 0.64 ;
       END
    END wmask0[1]
    PIN wmask0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  93.84 0.0 94.22 0.38 ;
+         RECT  93.84 0.0 94.22 0.64 ;
       END
    END wmask0[2]
    PIN wmask0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  98.6 0.0 98.98 0.38 ;
+         RECT  98.6 0.0 98.98 0.64 ;
       END
    END wmask0[3]
    PIN dout0[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  137.36 0.0 137.74 0.38 ;
+         RECT  137.36 0.0 137.74 0.64 ;
       END
    END dout0[0]
    PIN dout0[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  144.16 0.0 144.54 0.38 ;
+         RECT  144.16 0.0 144.54 0.64 ;
       END
    END dout0[1]
    PIN dout0[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  149.6 0.0 149.98 0.38 ;
+         RECT  149.6 0.0 149.98 0.64 ;
       END
    END dout0[2]
    PIN dout0[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  157.76 0.0 158.14 0.38 ;
+         RECT  157.76 0.0 158.14 0.64 ;
       END
    END dout0[3]
    PIN dout0[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  163.88 0.0 164.26 0.38 ;
+         RECT  163.88 0.0 164.26 0.64 ;
       END
    END dout0[4]
    PIN dout0[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  170.0 0.0 170.38 0.38 ;
+         RECT  170.0 0.0 170.38 0.64 ;
       END
    END dout0[5]
    PIN dout0[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  176.12 0.0 176.5 0.38 ;
+         RECT  176.12 0.0 176.5 0.64 ;
       END
    END dout0[6]
    PIN dout0[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  182.24 0.0 182.62 0.38 ;
+         RECT  182.24 0.0 182.62 0.64 ;
       END
    END dout0[7]
    PIN dout0[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  187.0 0.0 187.38 0.38 ;
+         RECT  187.0 0.0 187.38 0.64 ;
       END
    END dout0[8]
    PIN dout0[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  194.48 0.0 194.86 0.38 ;
+         RECT  194.48 0.0 194.86 0.64 ;
       END
    END dout0[9]
    PIN dout0[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  201.28 0.0 201.66 0.38 ;
+         RECT  201.28 0.0 201.66 0.64 ;
       END
    END dout0[10]
    PIN dout0[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  207.4 0.0 207.78 0.38 ;
+         RECT  207.4 0.0 207.78 0.64 ;
       END
    END dout0[11]
    PIN dout0[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  213.52 0.0 213.9 0.38 ;
+         RECT  213.52 0.0 213.9 0.64 ;
       END
    END dout0[12]
    PIN dout0[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  219.64 0.0 220.02 0.38 ;
+         RECT  219.64 0.0 220.02 0.64 ;
       END
    END dout0[13]
    PIN dout0[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  225.76 0.0 226.14 0.38 ;
+         RECT  225.76 0.0 226.14 0.64 ;
       END
    END dout0[14]
    PIN dout0[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  231.2 0.0 231.58 0.38 ;
+         RECT  231.2 0.0 231.58 0.64 ;
       END
    END dout0[15]
    PIN dout0[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  237.32 0.0 237.7 0.38 ;
+         RECT  237.32 0.0 237.7 0.64 ;
       END
    END dout0[16]
    PIN dout0[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  243.44 0.0 243.82 0.38 ;
+         RECT  243.44 0.0 243.82 0.64 ;
       END
    END dout0[17]
    PIN dout0[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  250.92 0.0 251.3 0.38 ;
+         RECT  250.92 0.0 251.3 0.64 ;
       END
    END dout0[18]
    PIN dout0[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  255.0 0.0 255.38 0.38 ;
+         RECT  255.0 0.0 255.38 0.64 ;
       END
    END dout0[19]
    PIN dout0[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  263.84 0.0 264.22 0.38 ;
+         RECT  263.84 0.0 264.22 0.64 ;
       END
    END dout0[20]
    PIN dout0[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  269.96 0.0 270.34 0.38 ;
+         RECT  269.96 0.0 270.34 0.64 ;
       END
    END dout0[21]
    PIN dout0[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  276.08 0.0 276.46 0.38 ;
+         RECT  276.08 0.0 276.46 0.64 ;
       END
    END dout0[22]
    PIN dout0[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  282.2 0.0 282.58 0.38 ;
+         RECT  282.2 0.0 282.58 0.64 ;
       END
    END dout0[23]
    PIN dout0[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  286.96 0.0 287.34 0.38 ;
+         RECT  286.96 0.0 287.34 0.64 ;
       END
    END dout0[24]
    PIN dout0[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  294.44 0.0 294.82 0.38 ;
+         RECT  294.44 0.0 294.82 0.64 ;
       END
    END dout0[25]
    PIN dout0[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  300.56 0.0 300.94 0.38 ;
+         RECT  300.56 0.0 300.94 0.64 ;
       END
    END dout0[26]
    PIN dout0[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  307.36 0.0 307.74 0.38 ;
+         RECT  307.36 0.0 307.74 0.64 ;
       END
    END dout0[27]
    PIN dout0[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  313.48 0.0 313.86 0.38 ;
+         RECT  313.48 0.0 313.86 0.64 ;
       END
    END dout0[28]
    PIN dout0[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  319.6 0.0 319.98 0.38 ;
+         RECT  319.6 0.0 319.98 0.64 ;
       END
    END dout0[29]
    PIN dout0[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  325.72 0.0 326.1 0.38 ;
+         RECT  325.72 0.0 326.1 0.64 ;
       END
    END dout0[30]
    PIN dout0[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  331.84 0.0 332.22 0.38 ;
+         RECT  331.84 0.0 332.22 0.64 ;
       END
    END dout0[31]
    PIN dout1[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  138.72 394.4 139.1 394.78 ;
+         RECT  138.72 394.14 139.1 394.78 ;
       END
    END dout1[0]
    PIN dout1[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  145.52 394.4 145.9 394.78 ;
+         RECT  145.52 394.14 145.9 394.78 ;
       END
    END dout1[1]
    PIN dout1[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  150.96 394.4 151.34 394.78 ;
+         RECT  150.96 394.14 151.34 394.78 ;
       END
    END dout1[2]
    PIN dout1[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  157.76 394.4 158.14 394.78 ;
+         RECT  157.76 394.14 158.14 394.78 ;
       END
    END dout1[3]
    PIN dout1[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  163.88 394.4 164.26 394.78 ;
+         RECT  163.88 394.14 164.26 394.78 ;
       END
    END dout1[4]
    PIN dout1[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  170.68 394.4 171.06 394.78 ;
+         RECT  170.68 394.14 171.06 394.78 ;
       END
    END dout1[5]
    PIN dout1[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  176.8 394.4 177.18 394.78 ;
+         RECT  176.8 394.14 177.18 394.78 ;
       END
    END dout1[6]
    PIN dout1[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  182.24 394.4 182.62 394.78 ;
+         RECT  182.24 394.14 182.62 394.78 ;
       END
    END dout1[7]
    PIN dout1[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  189.04 394.4 189.42 394.78 ;
+         RECT  189.04 394.14 189.42 394.78 ;
       END
    END dout1[8]
    PIN dout1[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  194.48 394.4 194.86 394.78 ;
+         RECT  194.48 394.14 194.86 394.78 ;
       END
    END dout1[9]
    PIN dout1[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  201.28 394.4 201.66 394.78 ;
+         RECT  201.28 394.14 201.66 394.78 ;
       END
    END dout1[10]
    PIN dout1[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  207.4 394.4 207.78 394.78 ;
+         RECT  207.4 394.14 207.78 394.78 ;
       END
    END dout1[11]
    PIN dout1[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  214.2 394.4 214.58 394.78 ;
+         RECT  214.2 394.14 214.58 394.78 ;
       END
    END dout1[12]
    PIN dout1[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  219.64 394.4 220.02 394.78 ;
+         RECT  219.64 394.14 220.02 394.78 ;
       END
    END dout1[13]
    PIN dout1[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  225.76 394.4 226.14 394.78 ;
+         RECT  225.76 394.14 226.14 394.78 ;
       END
    END dout1[14]
    PIN dout1[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  232.56 394.4 232.94 394.78 ;
+         RECT  232.56 394.14 232.94 394.78 ;
       END
    END dout1[15]
    PIN dout1[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  238.68 394.4 239.06 394.78 ;
+         RECT  238.68 394.14 239.06 394.78 ;
       END
    END dout1[16]
    PIN dout1[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  245.48 394.4 245.86 394.78 ;
+         RECT  245.48 394.14 245.86 394.78 ;
       END
    END dout1[17]
    PIN dout1[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  250.92 394.4 251.3 394.78 ;
+         RECT  250.92 394.14 251.3 394.78 ;
       END
    END dout1[18]
    PIN dout1[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  257.72 394.4 258.1 394.78 ;
+         RECT  257.72 394.14 258.1 394.78 ;
       END
    END dout1[19]
    PIN dout1[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  263.16 394.4 263.54 394.78 ;
+         RECT  263.16 394.14 263.54 394.78 ;
       END
    END dout1[20]
    PIN dout1[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  269.28 394.4 269.66 394.78 ;
+         RECT  269.28 394.14 269.66 394.78 ;
       END
    END dout1[21]
    PIN dout1[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  276.08 394.4 276.46 394.78 ;
+         RECT  276.08 394.14 276.46 394.78 ;
       END
    END dout1[22]
    PIN dout1[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  282.2 394.4 282.58 394.78 ;
+         RECT  282.2 394.14 282.58 394.78 ;
       END
    END dout1[23]
    PIN dout1[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  289.0 394.4 289.38 394.78 ;
+         RECT  289.0 394.14 289.38 394.78 ;
       END
    END dout1[24]
    PIN dout1[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  294.44 394.4 294.82 394.78 ;
+         RECT  294.44 394.14 294.82 394.78 ;
       END
    END dout1[25]
    PIN dout1[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  301.24 394.4 301.62 394.78 ;
+         RECT  301.24 394.14 301.62 394.78 ;
       END
    END dout1[26]
    PIN dout1[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  307.36 394.4 307.74 394.78 ;
+         RECT  307.36 394.14 307.74 394.78 ;
       END
    END dout1[27]
    PIN dout1[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  314.16 394.4 314.54 394.78 ;
+         RECT  314.16 394.14 314.54 394.78 ;
       END
    END dout1[28]
    PIN dout1[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  319.6 394.4 319.98 394.78 ;
+         RECT  319.6 394.14 319.98 394.78 ;
       END
    END dout1[29]
    PIN dout1[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  325.72 394.4 326.1 394.78 ;
+         RECT  325.72 394.14 326.1 394.78 ;
       END
    END dout1[30]
    PIN dout1[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  332.52 394.4 332.9 394.78 ;
+         RECT  332.52 394.14 332.9 394.78 ;
       END
    END dout1[31]
    PIN vccd1

--- a/sky130_sram_1kbyte_1rw1r_8x1024_8/sky130_sram_1kbyte_1rw1r_8x1024_8.lef
+++ b/sky130_sram_1kbyte_1rw1r_8x1024_8/sky130_sram_1kbyte_1rw1r_8x1024_8.lef
@@ -13,350 +13,350 @@ MACRO sky130_sram_1kbyte_1rw1r_8x1024_8
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  87.04 0.0 87.42 0.38 ;
+         RECT  87.04 0.0 87.42 0.64 ;
       END
    END din0[0]
    PIN din0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  93.16 0.0 93.54 0.38 ;
+         RECT  93.16 0.0 93.54 0.64 ;
       END
    END din0[1]
    PIN din0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  98.6 0.0 98.98 0.38 ;
+         RECT  98.6 0.0 98.98 0.64 ;
       END
    END din0[2]
    PIN din0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  104.04 0.0 104.42 0.38 ;
+         RECT  104.04 0.0 104.42 0.64 ;
       END
    END din0[3]
    PIN din0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  110.16 0.0 110.54 0.38 ;
+         RECT  110.16 0.0 110.54 0.64 ;
       END
    END din0[4]
    PIN din0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  115.6 0.0 115.98 0.38 ;
+         RECT  115.6 0.0 115.98 0.64 ;
       END
    END din0[5]
    PIN din0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  122.4 0.0 122.78 0.38 ;
+         RECT  122.4 0.0 122.78 0.64 ;
       END
    END din0[6]
    PIN din0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  127.16 0.0 127.54 0.38 ;
+         RECT  127.16 0.0 127.54 0.64 ;
       END
    END din0[7]
    PIN addr0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  63.24 0.0 63.62 0.38 ;
+         RECT  63.24 0.0 63.62 0.64 ;
       END
    END addr0[0]
    PIN addr0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  70.04 0.0 70.42 0.38 ;
+         RECT  70.04 0.0 70.42 0.64 ;
       END
    END addr0[1]
    PIN addr0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  75.48 0.0 75.86 0.38 ;
+         RECT  75.48 0.0 75.86 0.64 ;
       END
    END addr0[2]
    PIN addr0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 141.44 0.38 141.82 ;
+         RECT  0.0 141.44 0.64 141.82 ;
       END
    END addr0[3]
    PIN addr0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 149.6 0.38 149.98 ;
+         RECT  0.0 149.6 0.64 149.98 ;
       END
    END addr0[4]
    PIN addr0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 156.4 0.38 156.78 ;
+         RECT  0.0 156.4 0.64 156.78 ;
       END
    END addr0[5]
    PIN addr0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 164.56 0.38 164.94 ;
+         RECT  0.0 164.56 0.64 164.94 ;
       END
    END addr0[6]
    PIN addr0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 169.32 0.38 169.7 ;
+         RECT  0.0 169.32 0.64 169.7 ;
       END
    END addr0[7]
    PIN addr0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 177.48 0.38 177.86 ;
+         RECT  0.0 177.48 0.64 177.86 ;
       END
    END addr0[8]
    PIN addr0[9]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 183.6 0.38 183.98 ;
+         RECT  0.0 183.6 0.64 183.98 ;
       END
    END addr0[9]
    PIN addr1[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  382.16 442.68 382.54 443.06 ;
+         RECT  382.16 442.42 382.54 443.06 ;
       END
    END addr1[0]
    PIN addr1[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  376.72 442.68 377.1 443.06 ;
+         RECT  376.72 442.42 377.1 443.06 ;
       END
    END addr1[1]
    PIN addr1[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  371.28 442.68 371.66 443.06 ;
+         RECT  371.28 442.42 371.66 443.06 ;
       END
    END addr1[2]
    PIN addr1[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 97.24 451.9 97.62 ;
+         RECT  451.26 97.24 451.9 97.62 ;
       END
    END addr1[3]
    PIN addr1[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 88.4 451.9 88.78 ;
+         RECT  451.26 88.4 451.9 88.78 ;
       END
    END addr1[4]
    PIN addr1[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 82.96 451.9 83.34 ;
+         RECT  451.26 82.96 451.9 83.34 ;
       END
    END addr1[5]
    PIN addr1[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 74.12 451.9 74.5 ;
+         RECT  451.26 74.12 451.9 74.5 ;
       END
    END addr1[6]
    PIN addr1[7]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 68.68 451.9 69.06 ;
+         RECT  451.26 68.68 451.9 69.06 ;
       END
    END addr1[7]
    PIN addr1[8]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 59.84 451.9 60.22 ;
+         RECT  451.26 59.84 451.9 60.22 ;
       END
    END addr1[8]
    PIN addr1[9]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 53.72 451.9 54.1 ;
+         RECT  451.26 53.72 451.9 54.1 ;
       END
    END addr1[9]
    PIN csb0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 41.48 0.38 41.86 ;
+         RECT  0.0 41.48 0.64 41.86 ;
       END
    END csb0
    PIN csb1
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 395.76 451.9 396.14 ;
+         RECT  451.26 395.76 451.9 396.14 ;
       END
    END csb1
    PIN web0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 49.64 0.38 50.02 ;
+         RECT  0.0 49.64 0.64 50.02 ;
       END
    END web0
    PIN clk0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 42.16 0.38 42.54 ;
+         RECT  0.0 42.16 0.64 42.54 ;
       END
    END clk0
    PIN clk1
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  451.52 395.08 451.9 395.46 ;
+         RECT  451.26 395.08 451.9 395.46 ;
       END
    END clk1
    PIN wmask0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  80.92 0.0 81.3 0.38 ;
+         RECT  80.92 0.0 81.3 0.64 ;
       END
    END wmask0[0]
    PIN dout0[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  125.12 0.0 125.5 0.38 ;
+         RECT  125.12 0.0 125.5 0.64 ;
       END
    END dout0[0]
    PIN dout0[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  150.96 0.0 151.34 0.38 ;
+         RECT  150.96 0.0 151.34 0.64 ;
       END
    END dout0[1]
    PIN dout0[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  176.12 0.0 176.5 0.38 ;
+         RECT  176.12 0.0 176.5 0.64 ;
       END
    END dout0[2]
    PIN dout0[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  201.28 0.0 201.66 0.38 ;
+         RECT  201.28 0.0 201.66 0.64 ;
       END
    END dout0[3]
    PIN dout0[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  226.44 0.0 226.82 0.38 ;
+         RECT  226.44 0.0 226.82 0.64 ;
       END
    END dout0[4]
    PIN dout0[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  250.92 0.0 251.3 0.38 ;
+         RECT  250.92 0.0 251.3 0.64 ;
       END
    END dout0[5]
    PIN dout0[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  276.08 0.0 276.46 0.38 ;
+         RECT  276.08 0.0 276.46 0.64 ;
       END
    END dout0[6]
    PIN dout0[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  301.24 0.0 301.62 0.38 ;
+         RECT  301.24 0.0 301.62 0.64 ;
       END
    END dout0[7]
    PIN dout1[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  126.48 442.68 126.86 443.06 ;
+         RECT  126.48 442.42 126.86 443.06 ;
       END
    END dout1[0]
    PIN dout1[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  151.64 442.68 152.02 443.06 ;
+         RECT  151.64 442.42 152.02 443.06 ;
       END
    END dout1[1]
    PIN dout1[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  176.8 442.68 177.18 443.06 ;
+         RECT  176.8 442.42 177.18 443.06 ;
       END
    END dout1[2]
    PIN dout1[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  201.96 442.68 202.34 443.06 ;
+         RECT  201.96 442.42 202.34 443.06 ;
       END
    END dout1[3]
    PIN dout1[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  226.44 442.68 226.82 443.06 ;
+         RECT  226.44 442.42 226.82 443.06 ;
       END
    END dout1[4]
    PIN dout1[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  250.92 442.68 251.3 443.06 ;
+         RECT  250.92 442.42 251.3 443.06 ;
       END
    END dout1[5]
    PIN dout1[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  276.76 442.68 277.14 443.06 ;
+         RECT  276.76 442.42 277.14 443.06 ;
       END
    END dout1[6]
    PIN dout1[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  301.92 442.68 302.3 443.06 ;
+         RECT  301.92 442.42 302.3 443.06 ;
       END
    END dout1[7]
    PIN vccd1

--- a/sky130_sram_2kbyte_1rw1r_32x512_8/sky130_sram_2kbyte_1rw1r_32x512_8.lef
+++ b/sky130_sram_2kbyte_1rw1r_32x512_8/sky130_sram_2kbyte_1rw1r_32x512_8.lef
@@ -13,861 +13,861 @@ MACRO sky130_sram_2kbyte_1rw1r_32x512_8
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  113.56 0.0 113.94 0.38 ;
+         RECT  113.56 0.0 113.94 0.64 ;
       END
    END din0[0]
    PIN din0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  119.0 0.0 119.38 0.38 ;
+         RECT  119.0 0.0 119.38 0.64 ;
       END
    END din0[1]
    PIN din0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  125.12 0.0 125.5 0.38 ;
+         RECT  125.12 0.0 125.5 0.64 ;
       END
    END din0[2]
    PIN din0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  130.56 0.0 130.94 0.38 ;
+         RECT  130.56 0.0 130.94 0.64 ;
       END
    END din0[3]
    PIN din0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  136.0 0.0 136.38 0.38 ;
+         RECT  136.0 0.0 136.38 0.64 ;
       END
    END din0[4]
    PIN din0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  141.44 0.0 141.82 0.38 ;
+         RECT  141.44 0.0 141.82 0.64 ;
       END
    END din0[5]
    PIN din0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  148.24 0.0 148.62 0.38 ;
+         RECT  148.24 0.0 148.62 0.64 ;
       END
    END din0[6]
    PIN din0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  154.36 0.0 154.74 0.38 ;
+         RECT  154.36 0.0 154.74 0.64 ;
       END
    END din0[7]
    PIN din0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  159.8 0.0 160.18 0.38 ;
+         RECT  159.8 0.0 160.18 0.64 ;
       END
    END din0[8]
    PIN din0[9]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  165.24 0.0 165.62 0.38 ;
+         RECT  165.24 0.0 165.62 0.64 ;
       END
    END din0[9]
    PIN din0[10]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  170.68 0.0 171.06 0.38 ;
+         RECT  170.68 0.0 171.06 0.64 ;
       END
    END din0[10]
    PIN din0[11]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  177.48 0.0 177.86 0.38 ;
+         RECT  177.48 0.0 177.86 0.64 ;
       END
    END din0[11]
    PIN din0[12]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  182.92 0.0 183.3 0.38 ;
+         RECT  182.92 0.0 183.3 0.64 ;
       END
    END din0[12]
    PIN din0[13]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  188.36 0.0 188.74 0.38 ;
+         RECT  188.36 0.0 188.74 0.64 ;
       END
    END din0[13]
    PIN din0[14]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  195.16 0.0 195.54 0.38 ;
+         RECT  195.16 0.0 195.54 0.64 ;
       END
    END din0[14]
    PIN din0[15]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  201.28 0.0 201.66 0.38 ;
+         RECT  201.28 0.0 201.66 0.64 ;
       END
    END din0[15]
    PIN din0[16]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  206.72 0.0 207.1 0.38 ;
+         RECT  206.72 0.0 207.1 0.64 ;
       END
    END din0[16]
    PIN din0[17]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  212.16 0.0 212.54 0.38 ;
+         RECT  212.16 0.0 212.54 0.64 ;
       END
    END din0[17]
    PIN din0[18]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  217.6 0.0 217.98 0.38 ;
+         RECT  217.6 0.0 217.98 0.64 ;
       END
    END din0[18]
    PIN din0[19]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  224.4 0.0 224.78 0.38 ;
+         RECT  224.4 0.0 224.78 0.64 ;
       END
    END din0[19]
    PIN din0[20]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  229.84 0.0 230.22 0.38 ;
+         RECT  229.84 0.0 230.22 0.64 ;
       END
    END din0[20]
    PIN din0[21]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  235.96 0.0 236.34 0.38 ;
+         RECT  235.96 0.0 236.34 0.64 ;
       END
    END din0[21]
    PIN din0[22]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  241.4 0.0 241.78 0.38 ;
+         RECT  241.4 0.0 241.78 0.64 ;
       END
    END din0[22]
    PIN din0[23]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  246.84 0.0 247.22 0.38 ;
+         RECT  246.84 0.0 247.22 0.64 ;
       END
    END din0[23]
    PIN din0[24]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  253.64 0.0 254.02 0.38 ;
+         RECT  253.64 0.0 254.02 0.64 ;
       END
    END din0[24]
    PIN din0[25]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  259.08 0.0 259.46 0.38 ;
+         RECT  259.08 0.0 259.46 0.64 ;
       END
    END din0[25]
    PIN din0[26]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  264.52 0.0 264.9 0.38 ;
+         RECT  264.52 0.0 264.9 0.64 ;
       END
    END din0[26]
    PIN din0[27]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  269.96 0.0 270.34 0.38 ;
+         RECT  269.96 0.0 270.34 0.64 ;
       END
    END din0[27]
    PIN din0[28]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  276.76 0.0 277.14 0.38 ;
+         RECT  276.76 0.0 277.14 0.64 ;
       END
    END din0[28]
    PIN din0[29]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  282.88 0.0 283.26 0.38 ;
+         RECT  282.88 0.0 283.26 0.64 ;
       END
    END din0[29]
    PIN din0[30]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  288.32 0.0 288.7 0.38 ;
+         RECT  288.32 0.0 288.7 0.64 ;
       END
    END din0[30]
    PIN din0[31]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  293.76 0.0 294.14 0.38 ;
+         RECT  293.76 0.0 294.14 0.64 ;
       END
    END din0[31]
    PIN addr0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  78.2 0.0 78.58 0.38 ;
+         RECT  78.2 0.0 78.58 0.64 ;
       END
    END addr0[0]
    PIN addr0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  83.64 0.0 84.02 0.38 ;
+         RECT  83.64 0.0 84.02 0.64 ;
       END
    END addr0[1]
    PIN addr0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 139.4 0.38 139.78 ;
+         RECT  0.0 139.4 0.64 139.78 ;
       END
    END addr0[2]
    PIN addr0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 148.24 0.38 148.62 ;
+         RECT  0.0 148.24 0.64 148.62 ;
       END
    END addr0[3]
    PIN addr0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 154.36 0.38 154.74 ;
+         RECT  0.0 154.36 0.64 154.74 ;
       END
    END addr0[4]
    PIN addr0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 162.52 0.38 162.9 ;
+         RECT  0.0 162.52 0.64 162.9 ;
       END
    END addr0[5]
    PIN addr0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 167.96 0.38 168.34 ;
+         RECT  0.0 167.96 0.64 168.34 ;
       END
    END addr0[6]
    PIN addr0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 177.48 0.38 177.86 ;
+         RECT  0.0 177.48 0.64 177.86 ;
       END
    END addr0[7]
    PIN addr0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 182.92 0.38 183.3 ;
+         RECT  0.0 182.92 0.64 183.3 ;
       END
    END addr0[8]
    PIN addr1[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  596.36 412.76 596.74 413.14 ;
+         RECT  596.36 412.5 596.74 413.14 ;
       END
    END addr1[0]
    PIN addr1[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  590.24 412.76 590.62 413.14 ;
+         RECT  590.24 412.5 590.62 413.14 ;
       END
    END addr1[1]
    PIN addr1[2]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  678.64 95.2 679.02 95.58 ;
+         RECT  678.38 95.2 679.02 95.58 ;
       END
    END addr1[2]
    PIN addr1[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  678.64 87.04 679.02 87.42 ;
+         RECT  678.38 87.04 679.02 87.42 ;
       END
    END addr1[3]
    PIN addr1[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  678.64 80.24 679.02 80.62 ;
+         RECT  678.38 80.24 679.02 80.62 ;
       END
    END addr1[4]
    PIN addr1[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  678.64 72.76 679.02 73.14 ;
+         RECT  678.38 72.76 679.02 73.14 ;
       END
    END addr1[5]
    PIN addr1[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  678.64 66.64 679.02 67.02 ;
+         RECT  678.38 66.64 679.02 67.02 ;
       END
    END addr1[6]
    PIN addr1[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  614.04 0.0 614.42 0.38 ;
+         RECT  614.04 0.0 614.42 0.64 ;
       END
    END addr1[7]
    PIN addr1[8]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  614.72 0.0 615.1 0.38 ;
+         RECT  614.72 0.0 615.1 0.64 ;
       END
    END addr1[8]
    PIN csb0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 38.76 0.38 39.14 ;
+         RECT  0.0 38.76 0.64 39.14 ;
       END
    END csb0
    PIN csb1
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  678.64 394.4 679.02 394.78 ;
+         RECT  678.38 394.4 679.02 394.78 ;
       END
    END csb1
    PIN web0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 48.28 0.38 48.66 ;
+         RECT  0.0 48.28 0.64 48.66 ;
       END
    END web0
    PIN clk0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 40.12 0.38 40.5 ;
+         RECT  0.0 40.12 0.64 40.5 ;
       END
    END clk0
    PIN clk1
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  652.12 412.76 652.5 413.14 ;
+         RECT  652.12 412.5 652.5 413.14 ;
       END
    END clk1
    PIN wmask0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  89.08 0.0 89.46 0.38 ;
+         RECT  89.08 0.0 89.46 0.64 ;
       END
    END wmask0[0]
    PIN wmask0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  95.88 0.0 96.26 0.38 ;
+         RECT  95.88 0.0 96.26 0.64 ;
       END
    END wmask0[1]
    PIN wmask0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  100.64 0.0 101.02 0.38 ;
+         RECT  100.64 0.0 101.02 0.64 ;
       END
    END wmask0[2]
    PIN wmask0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  106.76 0.0 107.14 0.38 ;
+         RECT  106.76 0.0 107.14 0.64 ;
       END
    END wmask0[3]
    PIN dout0[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  139.4 0.0 139.78 0.38 ;
+         RECT  139.4 0.0 139.78 0.64 ;
       END
    END dout0[0]
    PIN dout0[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  151.64 0.0 152.02 0.38 ;
+         RECT  151.64 0.0 152.02 0.64 ;
       END
    END dout0[1]
    PIN dout0[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  165.92 0.0 166.3 0.38 ;
+         RECT  165.92 0.0 166.3 0.64 ;
       END
    END dout0[2]
    PIN dout0[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  178.16 0.0 178.54 0.38 ;
+         RECT  178.16 0.0 178.54 0.64 ;
       END
    END dout0[3]
    PIN dout0[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  190.4 0.0 190.78 0.38 ;
+         RECT  190.4 0.0 190.78 0.64 ;
       END
    END dout0[4]
    PIN dout0[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  203.32 0.0 203.7 0.38 ;
+         RECT  203.32 0.0 203.7 0.64 ;
       END
    END dout0[5]
    PIN dout0[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  215.56 0.0 215.94 0.38 ;
+         RECT  215.56 0.0 215.94 0.64 ;
       END
    END dout0[6]
    PIN dout0[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  227.8 0.0 228.18 0.38 ;
+         RECT  227.8 0.0 228.18 0.64 ;
       END
    END dout0[7]
    PIN dout0[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  239.36 0.0 239.74 0.38 ;
+         RECT  239.36 0.0 239.74 0.64 ;
       END
    END dout0[8]
    PIN dout0[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  252.96 0.0 253.34 0.38 ;
+         RECT  252.96 0.0 253.34 0.64 ;
       END
    END dout0[9]
    PIN dout0[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  265.88 0.0 266.26 0.38 ;
+         RECT  265.88 0.0 266.26 0.64 ;
       END
    END dout0[10]
    PIN dout0[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  278.12 0.0 278.5 0.38 ;
+         RECT  278.12 0.0 278.5 0.64 ;
       END
    END dout0[11]
    PIN dout0[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  290.36 0.0 290.74 0.38 ;
+         RECT  290.36 0.0 290.74 0.64 ;
       END
    END dout0[12]
    PIN dout0[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  302.6 0.0 302.98 0.38 ;
+         RECT  302.6 0.0 302.98 0.64 ;
       END
    END dout0[13]
    PIN dout0[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  315.52 0.0 315.9 0.38 ;
+         RECT  315.52 0.0 315.9 0.64 ;
       END
    END dout0[14]
    PIN dout0[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  327.76 0.0 328.14 0.38 ;
+         RECT  327.76 0.0 328.14 0.64 ;
       END
    END dout0[15]
    PIN dout0[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  339.32 0.0 339.7 0.38 ;
+         RECT  339.32 0.0 339.7 0.64 ;
       END
    END dout0[16]
    PIN dout0[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  352.92 0.0 353.3 0.38 ;
+         RECT  352.92 0.0 353.3 0.64 ;
       END
    END dout0[17]
    PIN dout0[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  365.16 0.0 365.54 0.38 ;
+         RECT  365.16 0.0 365.54 0.64 ;
       END
    END dout0[18]
    PIN dout0[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  377.4 0.0 377.78 0.38 ;
+         RECT  377.4 0.0 377.78 0.64 ;
       END
    END dout0[19]
    PIN dout0[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  390.32 0.0 390.7 0.38 ;
+         RECT  390.32 0.0 390.7 0.64 ;
       END
    END dout0[20]
    PIN dout0[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  402.56 0.0 402.94 0.38 ;
+         RECT  402.56 0.0 402.94 0.64 ;
       END
    END dout0[21]
    PIN dout0[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  415.48 0.0 415.86 0.38 ;
+         RECT  415.48 0.0 415.86 0.64 ;
       END
    END dout0[22]
    PIN dout0[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  427.72 0.0 428.1 0.38 ;
+         RECT  427.72 0.0 428.1 0.64 ;
       END
    END dout0[23]
    PIN dout0[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  440.64 0.0 441.02 0.38 ;
+         RECT  440.64 0.0 441.02 0.64 ;
       END
    END dout0[24]
    PIN dout0[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  452.88 0.0 453.26 0.38 ;
+         RECT  452.88 0.0 453.26 0.64 ;
       END
    END dout0[25]
    PIN dout0[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  465.12 0.0 465.5 0.38 ;
+         RECT  465.12 0.0 465.5 0.64 ;
       END
    END dout0[26]
    PIN dout0[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  477.36 0.0 477.74 0.38 ;
+         RECT  477.36 0.0 477.74 0.64 ;
       END
    END dout0[27]
    PIN dout0[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  490.28 0.0 490.66 0.38 ;
+         RECT  490.28 0.0 490.66 0.64 ;
       END
    END dout0[28]
    PIN dout0[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  502.52 0.0 502.9 0.38 ;
+         RECT  502.52 0.0 502.9 0.64 ;
       END
    END dout0[29]
    PIN dout0[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  514.76 0.0 515.14 0.38 ;
+         RECT  514.76 0.0 515.14 0.64 ;
       END
    END dout0[30]
    PIN dout0[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  527.68 0.0 528.06 0.38 ;
+         RECT  527.68 0.0 528.06 0.64 ;
       END
    END dout0[31]
    PIN dout1[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  141.44 412.76 141.82 413.14 ;
+         RECT  141.44 412.5 141.82 413.14 ;
       END
    END dout1[0]
    PIN dout1[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  153.0 412.76 153.38 413.14 ;
+         RECT  153.0 412.5 153.38 413.14 ;
       END
    END dout1[1]
    PIN dout1[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  165.24 412.76 165.62 413.14 ;
+         RECT  165.24 412.5 165.62 413.14 ;
       END
    END dout1[2]
    PIN dout1[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  178.84 412.76 179.22 413.14 ;
+         RECT  178.84 412.5 179.22 413.14 ;
       END
    END dout1[3]
    PIN dout1[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  190.4 412.76 190.78 413.14 ;
+         RECT  190.4 412.5 190.78 413.14 ;
       END
    END dout1[4]
    PIN dout1[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  203.32 412.76 203.7 413.14 ;
+         RECT  203.32 412.5 203.7 413.14 ;
       END
    END dout1[5]
    PIN dout1[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  215.56 412.76 215.94 413.14 ;
+         RECT  215.56 412.5 215.94 413.14 ;
       END
    END dout1[6]
    PIN dout1[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  228.48 412.76 228.86 413.14 ;
+         RECT  228.48 412.5 228.86 413.14 ;
       END
    END dout1[7]
    PIN dout1[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  240.72 412.76 241.1 413.14 ;
+         RECT  240.72 412.5 241.1 413.14 ;
       END
    END dout1[8]
    PIN dout1[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  253.64 412.76 254.02 413.14 ;
+         RECT  253.64 412.5 254.02 413.14 ;
       END
    END dout1[9]
    PIN dout1[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  265.88 412.76 266.26 413.14 ;
+         RECT  265.88 412.5 266.26 413.14 ;
       END
    END dout1[10]
    PIN dout1[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  278.8 412.76 279.18 413.14 ;
+         RECT  278.8 412.5 279.18 413.14 ;
       END
    END dout1[11]
    PIN dout1[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  290.36 412.76 290.74 413.14 ;
+         RECT  290.36 412.5 290.74 413.14 ;
       END
    END dout1[12]
    PIN dout1[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  302.6 412.76 302.98 413.14 ;
+         RECT  302.6 412.5 302.98 413.14 ;
       END
    END dout1[13]
    PIN dout1[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  316.2 412.76 316.58 413.14 ;
+         RECT  316.2 412.5 316.58 413.14 ;
       END
    END dout1[14]
    PIN dout1[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  328.44 412.76 328.82 413.14 ;
+         RECT  328.44 412.5 328.82 413.14 ;
       END
    END dout1[15]
    PIN dout1[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  340.68 412.76 341.06 413.14 ;
+         RECT  340.68 412.5 341.06 413.14 ;
       END
    END dout1[16]
    PIN dout1[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  352.92 412.76 353.3 413.14 ;
+         RECT  352.92 412.5 353.3 413.14 ;
       END
    END dout1[17]
    PIN dout1[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  365.84 412.76 366.22 413.14 ;
+         RECT  365.84 412.5 366.22 413.14 ;
       END
    END dout1[18]
    PIN dout1[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  377.4 412.76 377.78 413.14 ;
+         RECT  377.4 412.5 377.78 413.14 ;
       END
    END dout1[19]
    PIN dout1[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  391.0 412.76 391.38 413.14 ;
+         RECT  391.0 412.5 391.38 413.14 ;
       END
    END dout1[20]
    PIN dout1[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  403.24 412.76 403.62 413.14 ;
+         RECT  403.24 412.5 403.62 413.14 ;
       END
    END dout1[21]
    PIN dout1[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  415.48 412.76 415.86 413.14 ;
+         RECT  415.48 412.5 415.86 413.14 ;
       END
    END dout1[22]
    PIN dout1[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  427.72 412.76 428.1 413.14 ;
+         RECT  427.72 412.5 428.1 413.14 ;
       END
    END dout1[23]
    PIN dout1[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  439.96 412.76 440.34 413.14 ;
+         RECT  439.96 412.5 440.34 413.14 ;
       END
    END dout1[24]
    PIN dout1[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  452.88 412.76 453.26 413.14 ;
+         RECT  452.88 412.5 453.26 413.14 ;
       END
    END dout1[25]
    PIN dout1[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  465.8 412.76 466.18 413.14 ;
+         RECT  465.8 412.5 466.18 413.14 ;
       END
    END dout1[26]
    PIN dout1[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  478.04 412.76 478.42 413.14 ;
+         RECT  478.04 412.5 478.42 413.14 ;
       END
    END dout1[27]
    PIN dout1[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  490.28 412.76 490.66 413.14 ;
+         RECT  490.28 412.5 490.66 413.14 ;
       END
    END dout1[28]
    PIN dout1[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  503.2 412.76 503.58 413.14 ;
+         RECT  503.2 412.5 503.58 413.14 ;
       END
    END dout1[29]
    PIN dout1[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  514.76 412.76 515.14 413.14 ;
+         RECT  514.76 412.5 515.14 413.14 ;
       END
    END dout1[30]
    PIN dout1[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  528.36 412.76 528.74 413.14 ;
+         RECT  528.36 412.5 528.74 413.14 ;
       END
    END dout1[31]
    PIN vccd1
@@ -906,7 +906,7 @@ MACRO sky130_sram_2kbyte_1rw1r_32x512_8
    LAYER  met2 ;
       RECT  0.62 0.62 678.4 412.52 ;
    LAYER  met3 ;
-      RECT  0.98 138.8 678.4 140.38 ;
+      RECT  0.98 138.8 678.4 140.64 ;
       RECT  0.62 140.38 0.98 147.64 ;
       RECT  0.62 149.22 0.98 153.76 ;
       RECT  0.62 155.34 0.98 161.92 ;

--- a/sky130_sram_4kbyte_1rw1r_32x1024_8/sky130_sram_4kbyte_1rw1r_32x1024_8.lef
+++ b/sky130_sram_4kbyte_1rw1r_32x1024_8/sky130_sram_4kbyte_1rw1r_32x1024_8.lef
@@ -13,875 +13,875 @@ MACRO sky130_sram_4kbyte_1rw1r_32x1024_8
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  116.28 0.0 116.66 0.38 ;
+         RECT  116.28 0.0 116.66 0.64 ;
       END
    END din0[0]
    PIN din0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  121.72 0.0 122.1 0.38 ;
+         RECT  121.72 0.0 122.1 0.64 ;
       END
    END din0[1]
    PIN din0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  127.84 0.0 128.22 0.38 ;
+         RECT  127.84 0.0 128.22 0.64 ;
       END
    END din0[2]
    PIN din0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  133.28 0.0 133.66 0.38 ;
+         RECT  133.28 0.0 133.66 0.64 ;
       END
    END din0[3]
    PIN din0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  138.72 0.0 139.1 0.38 ;
+         RECT  138.72 0.0 139.1 0.64 ;
       END
    END din0[4]
    PIN din0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  144.16 0.0 144.54 0.38 ;
+         RECT  144.16 0.0 144.54 0.64 ;
       END
    END din0[5]
    PIN din0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  150.96 0.0 151.34 0.38 ;
+         RECT  150.96 0.0 151.34 0.64 ;
       END
    END din0[6]
    PIN din0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  157.08 0.0 157.46 0.38 ;
+         RECT  157.08 0.0 157.46 0.64 ;
       END
    END din0[7]
    PIN din0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  162.52 0.0 162.9 0.38 ;
+         RECT  162.52 0.0 162.9 0.64 ;
       END
    END din0[8]
    PIN din0[9]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  167.96 0.0 168.34 0.38 ;
+         RECT  167.96 0.0 168.34 0.64 ;
       END
    END din0[9]
    PIN din0[10]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  173.4 0.0 173.78 0.38 ;
+         RECT  173.4 0.0 173.78 0.64 ;
       END
    END din0[10]
    PIN din0[11]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  180.2 0.0 180.58 0.38 ;
+         RECT  180.2 0.0 180.58 0.64 ;
       END
    END din0[11]
    PIN din0[12]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  185.64 0.0 186.02 0.38 ;
+         RECT  185.64 0.0 186.02 0.64 ;
       END
    END din0[12]
    PIN din0[13]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  191.08 0.0 191.46 0.38 ;
+         RECT  191.08 0.0 191.46 0.64 ;
       END
    END din0[13]
    PIN din0[14]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  197.88 0.0 198.26 0.38 ;
+         RECT  197.88 0.0 198.26 0.64 ;
       END
    END din0[14]
    PIN din0[15]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  204.0 0.0 204.38 0.38 ;
+         RECT  204.0 0.0 204.38 0.64 ;
       END
    END din0[15]
    PIN din0[16]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  209.44 0.0 209.82 0.38 ;
+         RECT  209.44 0.0 209.82 0.64 ;
       END
    END din0[16]
    PIN din0[17]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  214.88 0.0 215.26 0.38 ;
+         RECT  214.88 0.0 215.26 0.64 ;
       END
    END din0[17]
    PIN din0[18]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  220.32 0.0 220.7 0.38 ;
+         RECT  220.32 0.0 220.7 0.64 ;
       END
    END din0[18]
    PIN din0[19]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  227.12 0.0 227.5 0.38 ;
+         RECT  227.12 0.0 227.5 0.64 ;
       END
    END din0[19]
    PIN din0[20]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  232.56 0.0 232.94 0.38 ;
+         RECT  232.56 0.0 232.94 0.64 ;
       END
    END din0[20]
    PIN din0[21]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  238.68 0.0 239.06 0.38 ;
+         RECT  238.68 0.0 239.06 0.64 ;
       END
    END din0[21]
    PIN din0[22]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  244.12 0.0 244.5 0.38 ;
+         RECT  244.12 0.0 244.5 0.64 ;
       END
    END din0[22]
    PIN din0[23]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  249.56 0.0 249.94 0.38 ;
+         RECT  249.56 0.0 249.94 0.64 ;
       END
    END din0[23]
    PIN din0[24]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  256.36 0.0 256.74 0.38 ;
+         RECT  256.36 0.0 256.74 0.64 ;
       END
    END din0[24]
    PIN din0[25]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  261.8 0.0 262.18 0.38 ;
+         RECT  261.8 0.0 262.18 0.64 ;
       END
    END din0[25]
    PIN din0[26]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  267.24 0.0 267.62 0.38 ;
+         RECT  267.24 0.0 267.62 0.64 ;
       END
    END din0[26]
    PIN din0[27]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  272.68 0.0 273.06 0.38 ;
+         RECT  272.68 0.0 273.06 0.64 ;
       END
    END din0[27]
    PIN din0[28]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  279.48 0.0 279.86 0.38 ;
+         RECT  279.48 0.0 279.86 0.64 ;
       END
    END din0[28]
    PIN din0[29]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  285.6 0.0 285.98 0.38 ;
+         RECT  285.6 0.0 285.98 0.64 ;
       END
    END din0[29]
    PIN din0[30]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  291.04 0.0 291.42 0.38 ;
+         RECT  291.04 0.0 291.42 0.64 ;
       END
    END din0[30]
    PIN din0[31]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  296.48 0.0 296.86 0.38 ;
+         RECT  296.48 0.0 296.86 0.64 ;
       END
    END din0[31]
    PIN addr0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  80.92 0.0 81.3 0.38 ;
+         RECT  80.92 0.0 81.3 0.64 ;
       END
    END addr0[0]
    PIN addr0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  86.36 0.0 86.74 0.38 ;
+         RECT  86.36 0.0 86.74 0.64 ;
       END
    END addr0[1]
    PIN addr0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 147.56 0.38 147.94 ;
+         RECT  0.0 147.56 0.64 147.94 ;
       END
    END addr0[2]
    PIN addr0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 155.72 0.38 156.1 ;
+         RECT  0.0 155.72 0.64 156.1 ;
       END
    END addr0[3]
    PIN addr0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 162.52 0.38 162.9 ;
+         RECT  0.0 162.52 0.64 162.9 ;
       END
    END addr0[4]
    PIN addr0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 171.36 0.38 171.74 ;
+         RECT  0.0 171.36 0.64 171.74 ;
       END
    END addr0[5]
    PIN addr0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 176.12 0.38 176.5 ;
+         RECT  0.0 176.12 0.64 176.5 ;
       END
    END addr0[6]
    PIN addr0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 184.28 0.38 184.66 ;
+         RECT  0.0 184.28 0.64 184.66 ;
       END
    END addr0[7]
    PIN addr0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 189.72 0.38 190.1 ;
+         RECT  0.0 189.72 0.64 190.1 ;
       END
    END addr0[8]
    PIN addr0[9]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 199.24 0.38 199.62 ;
+         RECT  0.0 199.24 0.64 199.62 ;
       END
    END addr0[9]
    PIN addr1[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  603.84 665.72 604.22 666.1 ;
+         RECT  603.84 665.46 604.22 666.1 ;
       END
    END addr1[0]
    PIN addr1[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  597.72 665.72 598.1 666.1 ;
+         RECT  597.72 665.46 598.1 666.1 ;
       END
    END addr1[1]
    PIN addr1[2]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  689.52 95.2 689.9 95.58 ;
+         RECT  689.26 95.2 689.9 95.58 ;
       END
    END addr1[2]
    PIN addr1[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  689.52 87.04 689.9 87.42 ;
+         RECT  689.26 87.04 689.9 87.42 ;
       END
    END addr1[3]
    PIN addr1[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  689.52 80.92 689.9 81.3 ;
+         RECT  689.26 80.92 689.9 81.3 ;
       END
    END addr1[4]
    PIN addr1[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  689.52 72.08 689.9 72.46 ;
+         RECT  689.26 72.08 689.9 72.46 ;
       END
    END addr1[5]
    PIN addr1[6]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  622.2 0.0 622.58 0.38 ;
+         RECT  622.2 0.0 622.58 0.64 ;
       END
    END addr1[6]
    PIN addr1[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  620.16 0.0 620.54 0.38 ;
+         RECT  620.16 0.0 620.54 0.64 ;
       END
    END addr1[7]
    PIN addr1[8]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  620.84 0.0 621.22 0.38 ;
+         RECT  620.84 0.0 621.22 0.64 ;
       END
    END addr1[8]
    PIN addr1[9]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  621.52 0.0 621.9 0.38 ;
+         RECT  621.52 0.0 621.9 0.64 ;
       END
    END addr1[9]
    PIN csb0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 38.76 0.38 39.14 ;
+         RECT  0.0 38.76 0.64 39.14 ;
       END
    END csb0
    PIN csb1
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  689.52 648.04 689.9 648.42 ;
+         RECT  689.26 648.04 689.9 648.42 ;
       END
    END csb1
    PIN web0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 47.6 0.38 47.98 ;
+         RECT  0.0 47.6 0.64 47.98 ;
       END
    END web0
    PIN clk0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 40.12 0.38 40.5 ;
+         RECT  0.0 40.12 0.64 40.5 ;
       END
    END clk0
    PIN clk1
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  661.64 665.72 662.02 666.1 ;
+         RECT  661.64 665.46 662.02 666.1 ;
       END
    END clk1
    PIN wmask0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  91.8 0.0 92.18 0.38 ;
+         RECT  91.8 0.0 92.18 0.64 ;
       END
    END wmask0[0]
    PIN wmask0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  98.6 0.0 98.98 0.38 ;
+         RECT  98.6 0.0 98.98 0.64 ;
       END
    END wmask0[1]
    PIN wmask0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  103.36 0.0 103.74 0.38 ;
+         RECT  103.36 0.0 103.74 0.64 ;
       END
    END wmask0[2]
    PIN wmask0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  109.48 0.0 109.86 0.38 ;
+         RECT  109.48 0.0 109.86 0.64 ;
       END
    END wmask0[3]
    PIN dout0[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  142.8 0.0 143.18 0.38 ;
+         RECT  142.8 0.0 143.18 0.64 ;
       END
    END dout0[0]
    PIN dout0[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  157.76 0.0 158.14 0.38 ;
+         RECT  157.76 0.0 158.14 0.64 ;
       END
    END dout0[1]
    PIN dout0[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  170.0 0.0 170.38 0.38 ;
+         RECT  170.0 0.0 170.38 0.64 ;
       END
    END dout0[2]
    PIN dout0[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  182.92 0.0 183.3 0.38 ;
+         RECT  182.92 0.0 183.3 0.64 ;
       END
    END dout0[3]
    PIN dout0[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  195.16 0.0 195.54 0.38 ;
+         RECT  195.16 0.0 195.54 0.64 ;
       END
    END dout0[4]
    PIN dout0[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  206.72 0.0 207.1 0.38 ;
+         RECT  206.72 0.0 207.1 0.64 ;
       END
    END dout0[5]
    PIN dout0[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  218.96 0.0 219.34 0.38 ;
+         RECT  218.96 0.0 219.34 0.64 ;
       END
    END dout0[6]
    PIN dout0[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  230.52 0.0 230.9 0.38 ;
+         RECT  230.52 0.0 230.9 0.64 ;
       END
    END dout0[7]
    PIN dout0[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  247.52 0.0 247.9 0.38 ;
+         RECT  247.52 0.0 247.9 0.64 ;
       END
    END dout0[8]
    PIN dout0[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  257.72 0.0 258.1 0.38 ;
+         RECT  257.72 0.0 258.1 0.64 ;
       END
    END dout0[9]
    PIN dout0[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  270.64 0.0 271.02 0.38 ;
+         RECT  270.64 0.0 271.02 0.64 ;
       END
    END dout0[10]
    PIN dout0[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  282.88 0.0 283.26 0.38 ;
+         RECT  282.88 0.0 283.26 0.64 ;
       END
    END dout0[11]
    PIN dout0[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  294.44 0.0 294.82 0.38 ;
+         RECT  294.44 0.0 294.82 0.64 ;
       END
    END dout0[12]
    PIN dout0[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  307.36 0.0 307.74 0.38 ;
+         RECT  307.36 0.0 307.74 0.64 ;
       END
    END dout0[13]
    PIN dout0[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  320.28 0.0 320.66 0.38 ;
+         RECT  320.28 0.0 320.66 0.64 ;
       END
    END dout0[14]
    PIN dout0[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  332.52 0.0 332.9 0.38 ;
+         RECT  332.52 0.0 332.9 0.64 ;
       END
    END dout0[15]
    PIN dout0[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  345.44 0.0 345.82 0.38 ;
+         RECT  345.44 0.0 345.82 0.64 ;
       END
    END dout0[16]
    PIN dout0[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  357.68 0.0 358.06 0.38 ;
+         RECT  357.68 0.0 358.06 0.64 ;
       END
    END dout0[17]
    PIN dout0[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  369.92 0.0 370.3 0.38 ;
+         RECT  369.92 0.0 370.3 0.64 ;
       END
    END dout0[18]
    PIN dout0[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  382.16 0.0 382.54 0.38 ;
+         RECT  382.16 0.0 382.54 0.64 ;
       END
    END dout0[19]
    PIN dout0[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  395.08 0.0 395.46 0.38 ;
+         RECT  395.08 0.0 395.46 0.64 ;
       END
    END dout0[20]
    PIN dout0[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  407.32 0.0 407.7 0.38 ;
+         RECT  407.32 0.0 407.7 0.64 ;
       END
    END dout0[21]
    PIN dout0[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  419.56 0.0 419.94 0.38 ;
+         RECT  419.56 0.0 419.94 0.64 ;
       END
    END dout0[22]
    PIN dout0[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  432.48 0.0 432.86 0.38 ;
+         RECT  432.48 0.0 432.86 0.64 ;
       END
    END dout0[23]
    PIN dout0[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  443.36 0.0 443.74 0.38 ;
+         RECT  443.36 0.0 443.74 0.64 ;
       END
    END dout0[24]
    PIN dout0[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  457.64 0.0 458.02 0.38 ;
+         RECT  457.64 0.0 458.02 0.64 ;
       END
    END dout0[25]
    PIN dout0[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  469.88 0.0 470.26 0.38 ;
+         RECT  469.88 0.0 470.26 0.64 ;
       END
    END dout0[26]
    PIN dout0[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  482.12 0.0 482.5 0.38 ;
+         RECT  482.12 0.0 482.5 0.64 ;
       END
    END dout0[27]
    PIN dout0[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  495.04 0.0 495.42 0.38 ;
+         RECT  495.04 0.0 495.42 0.64 ;
       END
    END dout0[28]
    PIN dout0[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  507.28 0.0 507.66 0.38 ;
+         RECT  507.28 0.0 507.66 0.64 ;
       END
    END dout0[29]
    PIN dout0[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  519.52 0.0 519.9 0.38 ;
+         RECT  519.52 0.0 519.9 0.64 ;
       END
    END dout0[30]
    PIN dout0[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  532.44 0.0 532.82 0.38 ;
+         RECT  532.44 0.0 532.82 0.64 ;
       END
    END dout0[31]
    PIN dout1[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  146.2 665.72 146.58 666.1 ;
+         RECT  146.2 665.46 146.58 666.1 ;
       END
    END dout1[0]
    PIN dout1[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  157.76 665.72 158.14 666.1 ;
+         RECT  157.76 665.46 158.14 666.1 ;
       END
    END dout1[1]
    PIN dout1[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  170.68 665.72 171.06 666.1 ;
+         RECT  170.68 665.46 171.06 666.1 ;
       END
    END dout1[2]
    PIN dout1[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  182.92 665.72 183.3 666.1 ;
+         RECT  182.92 665.46 183.3 666.1 ;
       END
    END dout1[3]
    PIN dout1[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  195.84 665.72 196.22 666.1 ;
+         RECT  195.84 665.46 196.22 666.1 ;
       END
    END dout1[4]
    PIN dout1[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  208.08 665.72 208.46 666.1 ;
+         RECT  208.08 665.46 208.46 666.1 ;
       END
    END dout1[5]
    PIN dout1[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  221.0 665.72 221.38 666.1 ;
+         RECT  221.0 665.46 221.38 666.1 ;
       END
    END dout1[6]
    PIN dout1[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  233.24 665.72 233.62 666.1 ;
+         RECT  233.24 665.46 233.62 666.1 ;
       END
    END dout1[7]
    PIN dout1[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  245.48 665.72 245.86 666.1 ;
+         RECT  245.48 665.46 245.86 666.1 ;
       END
    END dout1[8]
    PIN dout1[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  257.72 665.72 258.1 666.1 ;
+         RECT  257.72 665.46 258.1 666.1 ;
       END
    END dout1[9]
    PIN dout1[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  269.96 665.72 270.34 666.1 ;
+         RECT  269.96 665.46 270.34 666.1 ;
       END
    END dout1[10]
    PIN dout1[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  282.88 665.72 283.26 666.1 ;
+         RECT  282.88 665.46 283.26 666.1 ;
       END
    END dout1[11]
    PIN dout1[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  295.8 665.72 296.18 666.1 ;
+         RECT  295.8 665.46 296.18 666.1 ;
       END
    END dout1[12]
    PIN dout1[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  308.04 665.72 308.42 666.1 ;
+         RECT  308.04 665.46 308.42 666.1 ;
       END
    END dout1[13]
    PIN dout1[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  320.96 665.72 321.34 666.1 ;
+         RECT  320.96 665.46 321.34 666.1 ;
       END
    END dout1[14]
    PIN dout1[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  333.2 665.72 333.58 666.1 ;
+         RECT  333.2 665.46 333.58 666.1 ;
       END
    END dout1[15]
    PIN dout1[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  344.76 665.72 345.14 666.1 ;
+         RECT  344.76 665.46 345.14 666.1 ;
       END
    END dout1[16]
    PIN dout1[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  358.36 665.72 358.74 666.1 ;
+         RECT  358.36 665.46 358.74 666.1 ;
       END
    END dout1[17]
    PIN dout1[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  369.92 665.72 370.3 666.1 ;
+         RECT  369.92 665.46 370.3 666.1 ;
       END
    END dout1[18]
    PIN dout1[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  382.84 665.72 383.22 666.1 ;
+         RECT  382.84 665.46 383.22 666.1 ;
       END
    END dout1[19]
    PIN dout1[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  395.08 665.72 395.46 666.1 ;
+         RECT  395.08 665.46 395.46 666.1 ;
       END
    END dout1[20]
    PIN dout1[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  408.0 665.72 408.38 666.1 ;
+         RECT  408.0 665.46 408.38 666.1 ;
       END
    END dout1[21]
    PIN dout1[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  420.24 665.72 420.62 666.1 ;
+         RECT  420.24 665.46 420.62 666.1 ;
       END
    END dout1[22]
    PIN dout1[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  433.16 665.72 433.54 666.1 ;
+         RECT  433.16 665.46 433.54 666.1 ;
       END
    END dout1[23]
    PIN dout1[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  445.4 665.72 445.78 666.1 ;
+         RECT  445.4 665.46 445.78 666.1 ;
       END
    END dout1[24]
    PIN dout1[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  457.64 665.72 458.02 666.1 ;
+         RECT  457.64 665.46 458.02 666.1 ;
       END
    END dout1[25]
    PIN dout1[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  469.88 665.72 470.26 666.1 ;
+         RECT  469.88 665.46 470.26 666.1 ;
       END
    END dout1[26]
    PIN dout1[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  482.12 665.72 482.5 666.1 ;
+         RECT  482.12 665.46 482.5 666.1 ;
       END
    END dout1[27]
    PIN dout1[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  495.04 665.72 495.42 666.1 ;
+         RECT  495.04 665.46 495.42 666.1 ;
       END
    END dout1[28]
    PIN dout1[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  507.96 665.72 508.34 666.1 ;
+         RECT  507.96 665.46 508.34 666.1 ;
       END
    END dout1[29]
    PIN dout1[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  520.2 665.72 520.58 666.1 ;
+         RECT  520.2 665.46 520.58 666.1 ;
       END
    END dout1[30]
    PIN dout1[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  533.12 665.72 533.5 666.1 ;
+         RECT  533.12 665.46 533.5 666.1 ;
       END
    END dout1[31]
    PIN vccd1

--- a/sky130_sram_8kbyte_1rw1r_32x2048_8/sky130_sram_8kbyte_1rw1r_32x2048_8.lef
+++ b/sky130_sram_8kbyte_1rw1r_32x2048_8/sky130_sram_8kbyte_1rw1r_32x2048_8.lef
@@ -13,889 +13,889 @@ MACRO sky130_sram_8kbyte_1rw1r_32x2048_8
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  123.08 0.0 123.46 0.38 ;
+         RECT  123.08 0.0 123.46 0.64 ;
       END
    END din0[0]
    PIN din0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  129.88 0.0 130.26 0.38 ;
+         RECT  129.88 0.0 130.26 0.64 ;
       END
    END din0[1]
    PIN din0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  135.32 0.0 135.7 0.38 ;
+         RECT  135.32 0.0 135.7 0.64 ;
       END
    END din0[2]
    PIN din0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  141.44 0.0 141.82 0.38 ;
+         RECT  141.44 0.0 141.82 0.64 ;
       END
    END din0[3]
    PIN din0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  146.2 0.0 146.58 0.38 ;
+         RECT  146.2 0.0 146.58 0.64 ;
       END
    END din0[4]
    PIN din0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  153.0 0.0 153.38 0.38 ;
+         RECT  153.0 0.0 153.38 0.64 ;
       END
    END din0[5]
    PIN din0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  158.44 0.0 158.82 0.38 ;
+         RECT  158.44 0.0 158.82 0.64 ;
       END
    END din0[6]
    PIN din0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  163.88 0.0 164.26 0.38 ;
+         RECT  163.88 0.0 164.26 0.64 ;
       END
    END din0[7]
    PIN din0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  170.0 0.0 170.38 0.38 ;
+         RECT  170.0 0.0 170.38 0.64 ;
       END
    END din0[8]
    PIN din0[9]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  175.44 0.0 175.82 0.38 ;
+         RECT  175.44 0.0 175.82 0.64 ;
       END
    END din0[9]
    PIN din0[10]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  182.24 0.0 182.62 0.38 ;
+         RECT  182.24 0.0 182.62 0.64 ;
       END
    END din0[10]
    PIN din0[11]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  187.68 0.0 188.06 0.38 ;
+         RECT  187.68 0.0 188.06 0.64 ;
       END
    END din0[11]
    PIN din0[12]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  193.12 0.0 193.5 0.38 ;
+         RECT  193.12 0.0 193.5 0.64 ;
       END
    END din0[12]
    PIN din0[13]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  199.24 0.0 199.62 0.38 ;
+         RECT  199.24 0.0 199.62 0.64 ;
       END
    END din0[13]
    PIN din0[14]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  204.68 0.0 205.06 0.38 ;
+         RECT  204.68 0.0 205.06 0.64 ;
       END
    END din0[14]
    PIN din0[15]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  211.48 0.0 211.86 0.38 ;
+         RECT  211.48 0.0 211.86 0.64 ;
       END
    END din0[15]
    PIN din0[16]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  216.92 0.0 217.3 0.38 ;
+         RECT  216.92 0.0 217.3 0.64 ;
       END
    END din0[16]
    PIN din0[17]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  223.04 0.0 223.42 0.38 ;
+         RECT  223.04 0.0 223.42 0.64 ;
       END
    END din0[17]
    PIN din0[18]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  229.16 0.0 229.54 0.38 ;
+         RECT  229.16 0.0 229.54 0.64 ;
       END
    END din0[18]
    PIN din0[19]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  234.6 0.0 234.98 0.38 ;
+         RECT  234.6 0.0 234.98 0.64 ;
       END
    END din0[19]
    PIN din0[20]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  240.04 0.0 240.42 0.38 ;
+         RECT  240.04 0.0 240.42 0.64 ;
       END
    END din0[20]
    PIN din0[21]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  245.48 0.0 245.86 0.38 ;
+         RECT  245.48 0.0 245.86 0.64 ;
       END
    END din0[21]
    PIN din0[22]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  251.6 0.0 251.98 0.38 ;
+         RECT  251.6 0.0 251.98 0.64 ;
       END
    END din0[22]
    PIN din0[23]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  257.72 0.0 258.1 0.38 ;
+         RECT  257.72 0.0 258.1 0.64 ;
       END
    END din0[23]
    PIN din0[24]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  263.84 0.0 264.22 0.38 ;
+         RECT  263.84 0.0 264.22 0.64 ;
       END
    END din0[24]
    PIN din0[25]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  269.28 0.0 269.66 0.38 ;
+         RECT  269.28 0.0 269.66 0.64 ;
       END
    END din0[25]
    PIN din0[26]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  274.72 0.0 275.1 0.38 ;
+         RECT  274.72 0.0 275.1 0.64 ;
       END
    END din0[26]
    PIN din0[27]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  280.84 0.0 281.22 0.38 ;
+         RECT  280.84 0.0 281.22 0.64 ;
       END
    END din0[27]
    PIN din0[28]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  286.96 0.0 287.34 0.38 ;
+         RECT  286.96 0.0 287.34 0.64 ;
       END
    END din0[28]
    PIN din0[29]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  293.08 0.0 293.46 0.38 ;
+         RECT  293.08 0.0 293.46 0.64 ;
       END
    END din0[29]
    PIN din0[30]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  299.2 0.0 299.58 0.38 ;
+         RECT  299.2 0.0 299.58 0.64 ;
       END
    END din0[30]
    PIN din0[31]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  303.96 0.0 304.34 0.38 ;
+         RECT  303.96 0.0 304.34 0.64 ;
       END
    END din0[31]
    PIN addr0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  82.28 0.0 82.66 0.38 ;
+         RECT  82.28 0.0 82.66 0.64 ;
       END
    END addr0[0]
    PIN addr0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  88.4 0.0 88.78 0.38 ;
+         RECT  88.4 0.0 88.78 0.64 ;
       END
    END addr0[1]
    PIN addr0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  93.84 0.0 94.22 0.38 ;
+         RECT  93.84 0.0 94.22 0.64 ;
       END
    END addr0[2]
    PIN addr0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 174.08 0.38 174.46 ;
+         RECT  0.0 174.08 0.64 174.46 ;
       END
    END addr0[3]
    PIN addr0[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 182.24 0.38 182.62 ;
+         RECT  0.0 182.24 0.64 182.62 ;
       END
    END addr0[4]
    PIN addr0[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 189.04 0.38 189.42 ;
+         RECT  0.0 189.04 0.64 189.42 ;
       END
    END addr0[5]
    PIN addr0[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 197.2 0.38 197.58 ;
+         RECT  0.0 197.2 0.64 197.58 ;
       END
    END addr0[6]
    PIN addr0[7]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 202.64 0.38 203.02 ;
+         RECT  0.0 202.64 0.64 203.02 ;
       END
    END addr0[7]
    PIN addr0[8]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 210.8 0.38 211.18 ;
+         RECT  0.0 210.8 0.64 211.18 ;
       END
    END addr0[8]
    PIN addr0[9]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 216.24 0.38 216.62 ;
+         RECT  0.0 216.24 0.64 216.62 ;
       END
    END addr0[9]
    PIN addr0[10]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 225.76 0.38 226.14 ;
+         RECT  0.0 225.76 0.64 226.14 ;
       END
    END addr0[10]
    PIN addr1[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  1005.04 720.12 1005.42 720.5 ;
+         RECT  1005.04 719.86 1005.42 720.5 ;
       END
    END addr1[0]
    PIN addr1[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  999.6 720.12 999.98 720.5 ;
+         RECT  999.6 719.86 999.98 720.5 ;
       END
    END addr1[1]
    PIN addr1[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  992.8 720.12 993.18 720.5 ;
+         RECT  992.8 719.86 993.18 720.5 ;
       END
    END addr1[2]
    PIN addr1[3]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 121.04 1093.82 121.42 ;
+         RECT  1093.18 121.04 1093.82 121.42 ;
       END
    END addr1[3]
    PIN addr1[4]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 112.88 1093.82 113.26 ;
+         RECT  1093.18 112.88 1093.82 113.26 ;
       END
    END addr1[4]
    PIN addr1[5]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 107.44 1093.82 107.82 ;
+         RECT  1093.18 107.44 1093.82 107.82 ;
       END
    END addr1[5]
    PIN addr1[6]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 97.92 1093.82 98.3 ;
+         RECT  1093.18 97.92 1093.82 98.3 ;
       END
    END addr1[6]
    PIN addr1[7]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 92.48 1093.82 92.86 ;
+         RECT  1093.18 92.48 1093.82 92.86 ;
       END
    END addr1[7]
    PIN addr1[8]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 84.32 1093.82 84.7 ;
+         RECT  1093.18 84.32 1093.82 84.7 ;
       END
    END addr1[8]
    PIN addr1[9]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 78.88 1093.82 79.26 ;
+         RECT  1093.18 78.88 1093.82 79.26 ;
       END
    END addr1[9]
    PIN addr1[10]
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 70.72 1093.82 71.1 ;
+         RECT  1093.18 70.72 1093.82 71.1 ;
       END
    END addr1[10]
    PIN csb0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 65.96 0.38 66.34 ;
+         RECT  0.0 65.96 0.64 66.34 ;
       END
    END csb0
    PIN csb1
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 673.2 1093.82 673.58 ;
+         RECT  1093.18 673.2 1093.82 673.58 ;
       END
    END csb1
    PIN web0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 74.8 0.38 75.18 ;
+         RECT  0.0 74.8 0.64 75.18 ;
       END
    END web0
    PIN clk0
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  0.0 66.64 0.38 67.02 ;
+         RECT  0.0 66.64 0.64 67.02 ;
       END
    END clk0
    PIN clk1
       DIRECTION INPUT ;
       PORT
          LAYER met3 ;
-         RECT  1093.44 672.52 1093.82 672.9 ;
+         RECT  1093.18 672.52 1093.82 672.9 ;
       END
    END clk1
    PIN wmask0[0]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  99.96 0.0 100.34 0.38 ;
+         RECT  99.96 0.0 100.34 0.64 ;
       END
    END wmask0[0]
    PIN wmask0[1]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  105.4 0.0 105.78 0.38 ;
+         RECT  105.4 0.0 105.78 0.64 ;
       END
    END wmask0[1]
    PIN wmask0[2]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  111.52 0.0 111.9 0.38 ;
+         RECT  111.52 0.0 111.9 0.64 ;
       END
    END wmask0[2]
    PIN wmask0[3]
       DIRECTION INPUT ;
       PORT
          LAYER met4 ;
-         RECT  117.64 0.0 118.02 0.38 ;
+         RECT  117.64 0.0 118.02 0.64 ;
       END
    END wmask0[3]
    PIN dout0[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  144.84 0.0 145.22 0.38 ;
+         RECT  144.84 0.0 145.22 0.64 ;
       END
    END dout0[0]
    PIN dout0[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  172.72 0.0 173.1 0.38 ;
+         RECT  172.72 0.0 173.1 0.64 ;
       END
    END dout0[1]
    PIN dout0[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  197.2 0.0 197.58 0.38 ;
+         RECT  197.2 0.0 197.58 0.64 ;
       END
    END dout0[2]
    PIN dout0[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  221.0 0.0 221.38 0.38 ;
+         RECT  221.0 0.0 221.38 0.64 ;
       END
    END dout0[3]
    PIN dout0[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  247.52 0.0 247.9 0.38 ;
+         RECT  247.52 0.0 247.9 0.64 ;
       END
    END dout0[4]
    PIN dout0[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  272.68 0.0 273.06 0.38 ;
+         RECT  272.68 0.0 273.06 0.64 ;
       END
    END dout0[5]
    PIN dout0[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  296.48 0.0 296.86 0.38 ;
+         RECT  296.48 0.0 296.86 0.64 ;
       END
    END dout0[6]
    PIN dout0[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  322.32 0.0 322.7 0.38 ;
+         RECT  322.32 0.0 322.7 0.64 ;
       END
    END dout0[7]
    PIN dout0[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  347.48 0.0 347.86 0.38 ;
+         RECT  347.48 0.0 347.86 0.64 ;
       END
    END dout0[8]
    PIN dout0[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  371.96 0.0 372.34 0.38 ;
+         RECT  371.96 0.0 372.34 0.64 ;
       END
    END dout0[9]
    PIN dout0[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  397.12 0.0 397.5 0.38 ;
+         RECT  397.12 0.0 397.5 0.64 ;
       END
    END dout0[10]
    PIN dout0[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  421.6 0.0 421.98 0.38 ;
+         RECT  421.6 0.0 421.98 0.64 ;
       END
    END dout0[11]
    PIN dout0[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  446.76 0.0 447.14 0.38 ;
+         RECT  446.76 0.0 447.14 0.64 ;
       END
    END dout0[12]
    PIN dout0[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  471.92 0.0 472.3 0.38 ;
+         RECT  471.92 0.0 472.3 0.64 ;
       END
    END dout0[13]
    PIN dout0[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  497.08 0.0 497.46 0.38 ;
+         RECT  497.08 0.0 497.46 0.64 ;
       END
    END dout0[14]
    PIN dout0[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  521.56 0.0 521.94 0.38 ;
+         RECT  521.56 0.0 521.94 0.64 ;
       END
    END dout0[15]
    PIN dout0[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  545.36 0.0 545.74 0.38 ;
+         RECT  545.36 0.0 545.74 0.64 ;
       END
    END dout0[16]
    PIN dout0[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  571.88 0.0 572.26 0.38 ;
+         RECT  571.88 0.0 572.26 0.64 ;
       END
    END dout0[17]
    PIN dout0[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  596.36 0.0 596.74 0.38 ;
+         RECT  596.36 0.0 596.74 0.64 ;
       END
    END dout0[18]
    PIN dout0[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  621.52 0.0 621.9 0.38 ;
+         RECT  621.52 0.0 621.9 0.64 ;
       END
    END dout0[19]
    PIN dout0[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  646.68 0.0 647.06 0.38 ;
+         RECT  646.68 0.0 647.06 0.64 ;
       END
    END dout0[20]
    PIN dout0[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  671.84 0.0 672.22 0.38 ;
+         RECT  671.84 0.0 672.22 0.64 ;
       END
    END dout0[21]
    PIN dout0[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  696.32 0.0 696.7 0.38 ;
+         RECT  696.32 0.0 696.7 0.64 ;
       END
    END dout0[22]
    PIN dout0[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  721.48 0.0 721.86 0.38 ;
+         RECT  721.48 0.0 721.86 0.64 ;
       END
    END dout0[23]
    PIN dout0[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  745.28 0.0 745.66 0.38 ;
+         RECT  745.28 0.0 745.66 0.64 ;
       END
    END dout0[24]
    PIN dout0[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  771.12 0.0 771.5 0.38 ;
+         RECT  771.12 0.0 771.5 0.64 ;
       END
    END dout0[25]
    PIN dout0[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  796.28 0.0 796.66 0.38 ;
+         RECT  796.28 0.0 796.66 0.64 ;
       END
    END dout0[26]
    PIN dout0[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  821.44 0.0 821.82 0.38 ;
+         RECT  821.44 0.0 821.82 0.64 ;
       END
    END dout0[27]
    PIN dout0[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  845.92 0.0 846.3 0.38 ;
+         RECT  845.92 0.0 846.3 0.64 ;
       END
    END dout0[28]
    PIN dout0[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  871.08 0.0 871.46 0.38 ;
+         RECT  871.08 0.0 871.46 0.64 ;
       END
    END dout0[29]
    PIN dout0[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  896.24 0.0 896.62 0.38 ;
+         RECT  896.24 0.0 896.62 0.64 ;
       END
    END dout0[30]
    PIN dout0[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  921.4 0.0 921.78 0.38 ;
+         RECT  921.4 0.0 921.78 0.64 ;
       END
    END dout0[31]
    PIN dout1[0]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  147.56 720.12 147.94 720.5 ;
+         RECT  147.56 719.86 147.94 720.5 ;
       END
    END dout1[0]
    PIN dout1[1]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  172.04 720.12 172.42 720.5 ;
+         RECT  172.04 719.86 172.42 720.5 ;
       END
    END dout1[1]
    PIN dout1[2]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  197.2 720.12 197.58 720.5 ;
+         RECT  197.2 719.86 197.58 720.5 ;
       END
    END dout1[2]
    PIN dout1[3]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  222.36 720.12 222.74 720.5 ;
+         RECT  222.36 719.86 222.74 720.5 ;
       END
    END dout1[3]
    PIN dout1[4]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  247.52 720.12 247.9 720.5 ;
+         RECT  247.52 719.86 247.9 720.5 ;
       END
    END dout1[4]
    PIN dout1[5]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  272.68 720.12 273.06 720.5 ;
+         RECT  272.68 719.86 273.06 720.5 ;
       END
    END dout1[5]
    PIN dout1[6]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  297.16 720.12 297.54 720.5 ;
+         RECT  297.16 719.86 297.54 720.5 ;
       END
    END dout1[6]
    PIN dout1[7]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  322.32 720.12 322.7 720.5 ;
+         RECT  322.32 719.86 322.7 720.5 ;
       END
    END dout1[7]
    PIN dout1[8]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  347.48 720.12 347.86 720.5 ;
+         RECT  347.48 719.86 347.86 720.5 ;
       END
    END dout1[8]
    PIN dout1[9]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  372.64 720.12 373.02 720.5 ;
+         RECT  372.64 719.86 373.02 720.5 ;
       END
    END dout1[9]
    PIN dout1[10]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  397.8 720.12 398.18 720.5 ;
+         RECT  397.8 719.86 398.18 720.5 ;
       END
    END dout1[10]
    PIN dout1[11]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  421.6 720.12 421.98 720.5 ;
+         RECT  421.6 719.86 421.98 720.5 ;
       END
    END dout1[11]
    PIN dout1[12]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  446.76 720.12 447.14 720.5 ;
+         RECT  446.76 719.86 447.14 720.5 ;
       END
    END dout1[12]
    PIN dout1[13]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  472.6 720.12 472.98 720.5 ;
+         RECT  472.6 719.86 472.98 720.5 ;
       END
    END dout1[13]
    PIN dout1[14]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  497.08 720.12 497.46 720.5 ;
+         RECT  497.08 719.86 497.46 720.5 ;
       END
    END dout1[14]
    PIN dout1[15]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  521.56 720.12 521.94 720.5 ;
+         RECT  521.56 719.86 521.94 720.5 ;
       END
    END dout1[15]
    PIN dout1[16]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  546.72 720.12 547.1 720.5 ;
+         RECT  546.72 719.86 547.1 720.5 ;
       END
    END dout1[16]
    PIN dout1[17]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  571.88 720.12 572.26 720.5 ;
+         RECT  571.88 719.86 572.26 720.5 ;
       END
    END dout1[17]
    PIN dout1[18]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  596.36 720.12 596.74 720.5 ;
+         RECT  596.36 719.86 596.74 720.5 ;
       END
    END dout1[18]
    PIN dout1[19]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  621.52 720.12 621.9 720.5 ;
+         RECT  621.52 719.86 621.9 720.5 ;
       END
    END dout1[19]
    PIN dout1[20]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  646.68 720.12 647.06 720.5 ;
+         RECT  646.68 719.86 647.06 720.5 ;
       END
    END dout1[20]
    PIN dout1[21]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  671.84 720.12 672.22 720.5 ;
+         RECT  671.84 719.86 672.22 720.5 ;
       END
    END dout1[21]
    PIN dout1[22]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  697.0 720.12 697.38 720.5 ;
+         RECT  697.0 719.86 697.38 720.5 ;
       END
    END dout1[22]
    PIN dout1[23]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  721.48 720.12 721.86 720.5 ;
+         RECT  721.48 719.86 721.86 720.5 ;
       END
    END dout1[23]
    PIN dout1[24]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  746.64 720.12 747.02 720.5 ;
+         RECT  746.64 719.86 747.02 720.5 ;
       END
    END dout1[24]
    PIN dout1[25]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  771.8 720.12 772.18 720.5 ;
+         RECT  771.8 719.86 772.18 720.5 ;
       END
    END dout1[25]
    PIN dout1[26]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  796.96 720.12 797.34 720.5 ;
+         RECT  796.96 719.86 797.34 720.5 ;
       END
    END dout1[26]
    PIN dout1[27]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  822.12 720.12 822.5 720.5 ;
+         RECT  822.12 719.86 822.5 720.5 ;
       END
    END dout1[27]
    PIN dout1[28]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  845.92 720.12 846.3 720.5 ;
+         RECT  845.92 719.86 846.3 720.5 ;
       END
    END dout1[28]
    PIN dout1[29]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  871.08 720.12 871.46 720.5 ;
+         RECT  871.08 719.86 871.46 720.5 ;
       END
    END dout1[29]
    PIN dout1[30]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  896.92 720.12 897.3 720.5 ;
+         RECT  896.92 719.86 897.3 720.5 ;
       END
    END dout1[30]
    PIN dout1[31]
       DIRECTION OUTPUT ;
       PORT
          LAYER met4 ;
-         RECT  921.4 720.12 921.78 720.5 ;
+         RECT  921.4 719.86 921.78 720.5 ;
       END
    END dout1[31]
    PIN vccd1


### PR DESCRIPTION
sky130_sram_1kbyte_1rw1r_32x256_8  pins sizes changed to be slightly > 0.24
sky130_sram_1kbyte_1rw1r_8x1024_8 pins sizes changed to be slightly > 0.24

sky130_sram_2kbyte_1rw1r_32x512_8 pins sizes changed to be slightly > 0.24

sky130_sram_4kbyte_1rw1r_32x1024_8 pins sizes changed to be slightly > 0.24

sky130_sram_8kbyte_1rw1r_32x2048_8_pin_ext pins sizes changed to be slightly > 0.24