### PR TITLE
Set VERBOSE = 0

### DIFF
--- a/sky130_sram_1kbyte_1rw1r_32x256_8/sky130_sram_1kbyte_1rw1r_32x256_8.v
+++ b/sky130_sram_1kbyte_1rw1r_32x256_8/sky130_sram_1kbyte_1rw1r_32x256_8.v
@@ -20,7 +20,7 @@ module sky130_sram_1kbyte_1rw1r_32x256_8(
   parameter RAM_DEPTH = 1 << ADDR_WIDTH;
   // FIXME: This delay is arbitrary.
   parameter DELAY = 3 ;
-  parameter VERBOSE = 1 ; //Set to 0 to only display warnings
+  parameter VERBOSE = 0 ; //Set to 0 to only display warnings
   parameter T_HOLD = 1 ; //Delay to hold dout value after posedge. Value is arbitrary
 
 `ifdef USE_POWER_PINS

--- a/sky130_sram_1kbyte_1rw1r_8x1024_8/sky130_sram_1kbyte_1rw1r_8x1024_8.v
+++ b/sky130_sram_1kbyte_1rw1r_8x1024_8/sky130_sram_1kbyte_1rw1r_8x1024_8.v
@@ -20,7 +20,7 @@ module sky130_sram_1kbyte_1rw1r_8x1024_8(
   parameter RAM_DEPTH = 1 << ADDR_WIDTH;
   // FIXME: This delay is arbitrary.
   parameter DELAY = 3 ;
-  parameter VERBOSE = 1 ; //Set to 0 to only display warnings
+  parameter VERBOSE = 0 ; //Set to 0 to only display warnings
   parameter T_HOLD = 1 ; //Delay to hold dout value after posedge. Value is arbitrary
 
 `ifdef USE_POWER_PINS

--- a/sky130_sram_2kbyte_1rw1r_32x512_8/sky130_sram_2kbyte_1rw1r_32x512_8.v
+++ b/sky130_sram_2kbyte_1rw1r_32x512_8/sky130_sram_2kbyte_1rw1r_32x512_8.v
@@ -20,7 +20,7 @@ module sky130_sram_2kbyte_1rw1r_32x512_8(
   parameter RAM_DEPTH = 1 << ADDR_WIDTH;
   // FIXME: This delay is arbitrary.
   parameter DELAY = 3 ;
-  parameter VERBOSE = 1 ; //Set to 0 to only display warnings
+  parameter VERBOSE = 0 ; //Set to 0 to only display warnings
   parameter T_HOLD = 1 ; //Delay to hold dout value after posedge. Value is arbitrary
 
 `ifdef USE_POWER_PINS


### PR DESCRIPTION
The SRAM behaviourals are overly chatty. Microwatt does not need the
caravel management engine core, so holds it in reset. Even so, the
CI tests are seeing tens of thousands of the following:

575306 Reading simplebus_minimal_tb.uut.soc.core.sky130_sram_2kbyte_1rw1r_32x512_8 addr0=000000000 dout0=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

Set VERBOSE = 0, which someone can override if they want to see every
read and write from the SRAM.